### PR TITLE
Utilize user online marking and release version 5.5.0

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -16,7 +16,7 @@
     </authorinformation>
 
     <requiredpackages>
-        <requiredpackage minversion="5.5.11">com.woltlab.wcf</requiredpackage>
+        <requiredpackage minversion="5.5.18">com.woltlab.wcf</requiredpackage>
     </requiredpackages>
 
     <excludedpackages>
@@ -42,25 +42,12 @@
         <instruction type="box" />
     </instructions>
 
-    <instructions type="update" fromversion="5.4.0">
+    <instructions type="update" fromversion="5.4.*">
         <instruction type="file" />
         <instruction type="language" />
         <instruction type="template" />
         <instruction type="objectTypeDefinition" />
         <instruction type="objectType" />
         <instruction type="box" />
-    </instructions>
-
-    <instructions type="update" fromversion="5.4.1">
-        <instruction type="file" />
-        <instruction type="language" />
-        <instruction type="template" />
-        <instruction type="objectTypeDefinition" />
-        <instruction type="objectType" />
-        <instruction type="box" />
-    </instructions>
-
-    <instructions type="update" fromversion="5.4.2">
-        <instruction type="template" />
-    </instructions>
+    </instructions
 </package>

--- a/package.xml
+++ b/package.xml
@@ -33,16 +33,22 @@
         <instruction type="box" />
     </instructions>
 
-    <instructions type="update" fromversion="5.3.0">
+    <instructions type="update" fromversion="5.3.*">
         <instruction type="file" />
-    </instructions>
-
-    <instructions type="update" fromversion="5.3.1">
-        <instruction type="file" />
+        <instruction type="language" />
+        <instruction type="template" />
+        <instruction type="objectTypeDefinition" />
+        <instruction type="objectType" />
+        <instruction type="box" />
     </instructions>
 
     <instructions type="update" fromversion="5.4.0">
         <instruction type="file" />
+        <instruction type="language" />
+        <instruction type="template" />
+        <instruction type="objectTypeDefinition" />
+        <instruction type="objectType" />
+        <instruction type="box" />
     </instructions>
 
     <instructions type="update" fromversion="5.4.1">

--- a/package.xml
+++ b/package.xml
@@ -5,8 +5,8 @@
         <packagedescription>Provides an additional system box for configurably displaying the members with the most reactions.</packagedescription>
         <packagename language="de">Box „Mitglieder mit den meisten Reaktionen“</packagename>
         <packagedescription language="de">Ergänzt eine System-Box zur konfigurierbaren Anzeige der Mitglieder mit den meisten Reaktionen.</packagedescription>
-        <version>5.4.2</version>
-        <date>2022-09-18</date>
+        <version>5.5.0</version>
+        <date>2023-10-23</date>
         <license><![CDATA[LGPL <https://opensource.org/licenses/lgpl-license.php>]]></license>
     </packageinformation>
 
@@ -16,11 +16,11 @@
     </authorinformation>
 
     <requiredpackages>
-        <requiredpackage minversion="5.3.0">com.woltlab.wcf</requiredpackage>
+        <requiredpackage minversion="5.5.11">com.woltlab.wcf</requiredpackage>
     </requiredpackages>
 
     <excludedpackages>
-        <excludedpackage version="5.6.0 Alpha 1">com.woltlab.wcf</excludedpackage>
+        <excludedpackage version="6.0.0 Alpha 1">com.woltlab.wcf</excludedpackage>
         <excludedpackage version="*">com.uz.box.likes</excludedpackage>
     </excludedpackages>
 
@@ -58,5 +58,9 @@
         <instruction type="objectTypeDefinition" />
         <instruction type="objectType" />
         <instruction type="box" />
+    </instructions>
+
+    <instructions type="update" fromversion="5.4.2">
+        <instruction type="template" />
     </instructions>
 </package>

--- a/templates/boxUzLikes.tpl
+++ b/templates/boxUzLikes.tpl
@@ -4,7 +4,7 @@
             <a href="{link controller='User' object=$boxUser}{/link}" aria-hidden="true">{@$boxUser->getAvatar()->getImageTag(32)}</a>
 
             <div class="sidebarItemTitle">
-                <h3><a href="{link controller='User' object=$boxUser}{/link}" class="userLink" data-user-id="{@$boxUser->userID}">{$boxUser->username}</a></h3>
+                <h3>{user object=$boxUser}</h3>
                 <small>{lang}wcf.user.uzboxLikes.likes{/lang}</small>
             </div>
         </li>
@@ -18,7 +18,7 @@
                 <a href="{link controller='User' object=$boxUser}{/link}" aria-hidden="true">{@$boxUser->getAvatar()->getImageTag(32)}</a>
 
                 <div class="sidebarItemTitle">
-                    <h3><a href="{link controller='User' object=$boxUser}{/link}" class="userLink" data-user-id="{@$boxUser->userID}">{$boxUser->username}</a></h3>
+                    <h3>{user object=$boxUser}</h3>
                     <small>{lang}wcf.user.uzboxLikes.likes{/lang}</small>
                 </div>
             </li>


### PR DESCRIPTION
- Utilizes user online marking in box templates
- Requires WSC 5.5 due to the use of the `user` template plugin

I have also updated the update path from 5.3.X and 5.4.0. I am aware that technically those versions don't exist, but if the path is there and instructions were made for 5.4.2, the older ones should be correct. Otherwise, I guess they can just be removed aswell.

Feel free to suggest/make any adjustments.